### PR TITLE
Modified PSG Square composition to match specification on GBATEK page.

### DIFF
--- a/GBAMusicStudio/Config.yaml
+++ b/GBAMusicStudio/Config.yaml
@@ -5,7 +5,7 @@ Volume: 50 # Value between 0 and 100.
 
 # These can be reloaded in the program:
 
-PSGVolume: 1.0 # Value between 0.0 and 1.0. Applies to sounds loaded after updating.
+PSGVolume: 0.25 # Value between 0.0 and 1.0. Applies to sounds loaded after updating.
 MIDIKeyboardFixedVelocity: True # True or False.
 TaskbarProgress: True # True or False. Only works on Windows Vista & above.
 RefreshRate: 30 # Value over 0. # Requires a song state change to update.

--- a/GBAMusicStudio/Core/Instrument.cs
+++ b/GBAMusicStudio/Core/Instrument.cs
@@ -65,11 +65,8 @@ namespace GBAMusicStudio.Core
             }
             else
             {
-                float fundamental = 440 * (float)Math.Pow(2, (Note - 69) / 12f + Track.APitch / 768f);
-                if (Voice is M4APSG_Wave)
-                    frequency = fundamental * 0x10;
-                else // Squares
-                    frequency = fundamental * 0x100;
+                float fundamental = 220 * (float)Math.Pow(2, (Note - 69) / 12f + Track.APitch / 768f);
+                frequency = fundamental * 0x10;
             }
             Channel.setFrequency(FixedFrequency ? soundFrequency : frequency);
             UpdatePanpot();
@@ -119,7 +116,7 @@ namespace GBAMusicStudio.Core
                 S *= 16;
                 R *= 32;
             }
-            
+
             track.Instruments.Add(this);
         }
         internal void Stop()

--- a/GBAMusicStudio/Core/SongPlayer.cs
+++ b/GBAMusicStudio/Core/SongPlayer.cs
@@ -90,26 +90,28 @@ namespace GBAMusicStudio.Core
         }
         static void PSGSquare()
         {
-            byte[] simple = { 1, 2, 4, 6 };
-            uint len = 0x100;
-            var buf = new byte[len];
-
+            uint len = 0x8;
             int variance = (int)(0x7F * Config.PSGVolume);
             byte high = (byte)(0x80 + variance);
             byte low = (byte)(0x80 - variance);
+            byte[][] square_waves = new byte[][]{
+                new byte[]{ high, low, low, low, low, low, low, low },
+                new byte[]{ high, high, low, low, low, low, low, low },
+                new byte[]{ high, high, high, high, low, low, low, low },
+                new byte[]{ high, high, high, high, high, high, low, low }
+            };
+
 
             for (uint i = 0; i < 4; i++) // Squares
             {
-                for (int j = 0; j < len; j++)
-                    buf[j] = (j < simple[i] * 0x20 ? high : low);
                 var ex = new FMOD.CREATESOUNDEXINFO()
                 {
-                    defaultfrequency = 112640,
+                    defaultfrequency = 7040,
                     format = FMOD.SOUND_FORMAT.PCM8,
                     length = len,
                     numchannels = 1
                 };
-                System.createSound(buf, FMOD.MODE.OPENMEMORY | FMOD.MODE.OPENRAW | FMOD.MODE.LOOP_NORMAL | FMOD.MODE.LOWMEM, ref ex, out FMOD.Sound snd);
+                System.createSound(square_waves[i], FMOD.MODE.OPENMEMORY | FMOD.MODE.OPENRAW | FMOD.MODE.LOOP_NORMAL | FMOD.MODE.LOWMEM, ref ex, out FMOD.Sound snd);
                 Sounds.Add(SQUARE12_ID - i, snd);
             }
         }


### PR DESCRIPTION
I've modified the PSG Square waves to match the technical documentation on the GBATEK page.

AGB square waves should be generated in 3 groups of 8 periods per sample rather than 256 periods.